### PR TITLE
update groups/members route

### DIFF
--- a/specs/openapi.yaml
+++ b/specs/openapi.yaml
@@ -73,7 +73,7 @@ paths:
           links:
             pagination:
               $ref: "#/components/links/GroupPaging"
-  /v1/groups/{group_name}:
+  /v1/groups/{group_name}/members:
     get:
       operationId: getGroupMembers
       parameters:


### PR DESCRIPTION
updates the `/v1/groups/<groupname>` to `/v1/groups/<groupname>/members`  in the OpenAPI spec so the method route is rest-ish  and expressive on what it is about.