### PR TITLE
endpoints to list sponsors of a group and groups of a user

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,8 +8,14 @@ Usage
    {"result": [{"name": "test-group", "uri": "http://$(hostname)/fasjson/v1/groups/test-group/"}]}
    $ curl --negotiate -u : http://$(hostname)/fasjson/v1/groups/admins/
    {"result": {"name": "test-group", "uri": "http://fasjson.example.test/fasjson/v1/groups/test-group/"}}
+   $ curl --negotiate -u : http://$(hostname)/fasjson/v1/groups/admins/sponsors/
+   {"result": [{"username": "admin", [...]}, {"username": "user123", [...]}]}
+   $ curl --negotiate -u : http://$(hostname)/fasjson/v1/groups/admins/members/
+   {"result": [{"username": "admin", [...]}, {"username": "user123", [...]}]}
    $ curl --negotiate -u : http://$(hostname)/fasjson/v1/users/admin/
    {"result": {"username": "admin", "surname": "Administrator", "givenname": "", "emails": ["admin@$(domain)"], "ircnicks": null, "locale": "fr_FR", "timezone": null, "gpgkeyids": null, "creation": "2020-04-23T10:16:35", "locked": false, "uri": "http://$(hostname)/fasjson/v1/users/admin/"}}
+   $ curl --negotiate -u : http://$(hostname)/fasjson/v1/users/admin/groups/
+   {"result": [{"name": "test-group", "uri": "http://$(hostname)/fasjson/v1/groups/test-group/"}]}
    $ curl --negotiate -u : http://$(hostname)/fasjson/v1/search/users/?username=admin&ircnick=admin&surname=admin&givenname=admin&email=admin@example.test
    {"result": [{"username": "admin", [...]}, {"username": "badminton", [...]}]}
    $ curl --negotiate -u : http://$(hostname)/fasjson/v1/me/

--- a/fasjson/lib/ldap/models.py
+++ b/fasjson/lib/ldap/models.py
@@ -54,6 +54,15 @@ class UserModel(Model):
     }
 
 
+class SponsorModel(Model):
+    primary_key = "memberManager"
+    filters = "(&(objectClass=fasUser)(!(nsAccountLock=TRUE)))"
+    sub_dn = "cn=users,cn=accounts"
+    fields = {
+        "sponsors": Converter("memberManager", multivalued=True),
+    }
+
+
 class GroupModel(Model):
     primary_key = "cn"
     filters = "(objectClass=fasGroup)"

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -38,7 +38,7 @@ def test_whoami_user(mock_connection):
     r = "dn: uid=dummy,cn=users,cn=accounts,dc=example,dc=test"
     mock_connection.whoami_s = lambda: r
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     expected = {"dn": r[4:], "username": "dummy"}
     assert expected == ldap.whoami()
@@ -51,7 +51,7 @@ def test_whoami_service(mock_connection):
     )
     mock_connection.whoami_s = lambda: r
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     expected = {"dn": r[4:], "service": "test/fasjson.example.test"}
     assert expected == ldap.whoami()
@@ -66,7 +66,7 @@ def test_get_groups(mock_connection):
     ]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     result = ldap.get_groups(page_number=1, page_size=0)
     expected = LDAPResult(
@@ -87,14 +87,14 @@ def test_get_group(mock_connection):
     mocked = [{"cn": [b"dummy-group"]}]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     assert ldap.get_group("dummy-group") == {"groupname": "dummy-group"}
 
 
 def test_get_group_not_found(mock_connection):
     mock_connection.result3 = _single_page_result_factory([])
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     assert ldap.get_group("dummy-group") is None
 
 
@@ -102,7 +102,7 @@ def test_get_group_members(mock_connection):
     mocked = [{"uid": [b"admin"]}]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     result = ldap.get_group_members("admins", page_number=1, page_size=0)
     expected = LDAPResult(
@@ -122,7 +122,7 @@ def test_get_group_sponsors(mock_connection):
     mocked_conversion = [{"username": "admin"}]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     with mock.patch.object(
         ldap, "_sponsors_to_users", side_effect=[mocked_conversion]
     ):
@@ -134,15 +134,15 @@ def test_get_group_sponsors(mock_connection):
 
 def test_get_group_sponsors_none(mock_connection):
     mock_connection.result3 = _single_page_result_factory([])
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
-    assert ldap.get_group_sponsors("dummy") is None
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
+    assert ldap.get_group_sponsors("dummy") == []
 
 
 def test_sponsors_to_users(mock_connection):
     mocked = [{"uid": [b"admin"]}]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     sponsors_dn = LDAPResult(
         items=[
@@ -173,7 +173,7 @@ def test_get_users(mock_connection):
     mocked = [_get_mock_result(i) for i in range(1, 4)]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     result = ldap.get_users(page_number=1, page_size=0)
     creation_dt = datetime.datetime(2020, 3, 9, 10, 32, 3)
@@ -214,7 +214,7 @@ def test_get_user(mock_connection):
     ]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     expected = {
         "creation": datetime.datetime(2020, 3, 9, 10, 32, 3),
@@ -231,7 +231,7 @@ def test_get_user(mock_connection):
 
 def test_get_user_not_found(mock_connection):
     mock_connection.result3 = _single_page_result_factory([])
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     assert ldap.get_user("dummy") is None
 
 
@@ -244,7 +244,7 @@ def test_get_user_groups(mock_connection):
     ]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     result = ldap.get_user_groups(
         username="dummy", page_number=1, page_size=0
@@ -277,7 +277,7 @@ def test_search_users(mock_connection):
     mocked = [_get_mock_result(i) for i in range(1, 4)]
     mock_connection.result3 = _single_page_result_factory(mocked)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
 
     result = ldap.search_users(
         username="dummy",
@@ -312,7 +312,7 @@ def test_search_users(mock_connection):
 def test_get_paged_search_filters(mock_connection):
     mocked = []
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     with mock.patch.object(
         ldap, "_do_search", side_effect=[mocked]
     ) as do_search:
@@ -339,7 +339,7 @@ def test_get_paged_groups(mock_connection):
         {"cn": [f"group-{idx}".encode("ascii")]} for idx in range(1, 12)
     ]
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     with mock.patch.object(
         ldap, "_do_search", side_effect=[mocked, mocked[3:6]]
     ) as do_search:
@@ -366,7 +366,7 @@ def test_get_paged_groups(mock_connection):
 def test_get_paged_search_no_results(mock_connection):
     mocked = []
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     with mock.patch.object(
         ldap, "_do_search", side_effect=[mocked]
     ) as do_search:
@@ -416,7 +416,7 @@ def test_do_search_paged(mock_connection):
     ]
     mock_connection.result3 = mock.Mock(side_effect=pages)
 
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     result = ldap.get_groups(0, 1)
 
     expected = LDAPResult(
@@ -432,7 +432,7 @@ def test_do_search_other_server_control(mock_connection):
     dummy_server_control = object()
     ldap_return = [101, [], 1, [dummy_server_control]]
     mock_connection.result3 = mock.Mock(return_value=ldap_return)
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     ldap.get_groups(0, 1)
     # No loop
     assert mock_connection.result3.call_count == 1
@@ -441,7 +441,7 @@ def test_do_search_other_server_control(mock_connection):
 def test_do_search_no_server_control(mock_connection):
     ldap_return = [101, [], 1, []]
     mock_connection.result3 = mock.Mock(return_value=ldap_return)
-    ldap = LDAP("https://dummy.com", basedn="dc=example,dc=test")
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
     ldap.get_groups(0, 1)
     # No loop
     assert mock_connection.result3.call_count == 1

--- a/fasjson/tests/unit/test_web_resource_v1_groups.py
+++ b/fasjson/tests/unit/test_web_resource_v1_groups.py
@@ -116,6 +116,36 @@ def test_group_members_error(client, gss_user, mock_ldap_client):
     assert expected == rv.get_json()
 
 
+def test_group_sponsors_success(client, gss_user, mock_ldap_client):
+    result = [{"username": "admin"}]
+    mock_ldap_client(
+        get_group_sponsors=lambda groupname: result,
+        get_group=lambda n: {"cn": n},
+    )
+    rv = client.get("/v1/groups/admins/sponsors/")
+
+    expected = {
+        "result": [
+            {"username": "admin", "uri": "http://localhost/v1/users/admin/"}
+        ]
+    }
+    assert 200 == rv.status_code
+    assert expected == rv.get_json()
+
+
+def test_group_sponsors_error(client, gss_user, mock_ldap_client):
+    mock_ldap_client(get_group=lambda n: None,)
+
+    rv = client.get("/v1/groups/editors/sponsors/")
+
+    expected = {
+        "groupname": "editors",
+        "message": "Group not found",
+    }
+    assert 404 == rv.status_code
+    assert expected == rv.get_json()
+
+
 def test_group_success(client, gss_user, mock_ldap_client):
     mock_ldap_client(get_group=lambda n: {"groupname": "dummy-group"},)
 

--- a/fasjson/tests/unit/test_web_resource_v1_users.py
+++ b/fasjson/tests/unit/test_web_resource_v1_users.py
@@ -66,3 +66,32 @@ def test_users_success(client, gss_user, mock_ldap_client):
     expected = [_get_user_api_output(f"dummy-{idx}") for idx in range(1, 10)]
     assert 200 == rv.status_code
     assert rv.get_json() == {"result": expected}
+
+
+def test_user_groups_success(client, gss_user, mock_ldap_client):
+    groups = ["group1", "group2"]
+    result = LDAPResult(items=[{"groupname": name} for name in groups])
+    mock_ldap_client(
+        get_user_groups=lambda username, page_size, page_number: result,
+        get_user=lambda n: {"cn": n},
+    )
+
+    rv = client.get("/v1/users/dummy/groups/")
+    assert 200 == rv.status_code
+    assert rv.get_json() == {
+        "result": [
+            {"groupname": name, "uri": f"http://localhost/v1/groups/{name}/"}
+            for name in groups
+        ]
+    }
+
+
+def test_user_groups_error(client, gss_user, mock_ldap_client):
+    mock_ldap_client(get_user=lambda n: None)
+
+    rv = client.get("/v1/users/dummy/groups/")
+
+    expected = {"name": "dummy", "message": "User does not exist"}
+
+    assert 404 == rv.status_code
+    assert rv.get_json() == expected

--- a/fasjson/web/resources/groups.py
+++ b/fasjson/web/resources/groups.py
@@ -63,7 +63,7 @@ class Group(Resource):
 @api_v1.param("groupname", "The group name")
 @api_v1.response(404, "Group not found")
 class GroupMembers(Resource):
-    @api_v1.doc("get_group_members")
+    @api_v1.doc("list_group_members")
     @api_v1.expect(page_request_parser)
     @api_v1.paged_marshal_with(MemberModel, "v1.groups_group_members")
     def get(self, groupname):
@@ -84,10 +84,10 @@ class GroupMembers(Resource):
 @api_v1.param("groupname", "The group name")
 @api_v1.response(404, "Group not found")
 class GroupSponsors(Resource):
-    @api_v1.doc("get_group_sponsors")
+    @api_v1.doc("list_group_sponsors")
     @api_v1.marshal_with(SponsorModel)
     def get(self, groupname):
-        """Fetch group members given the group name"""
+        """Fetch group sponsors given the group name"""
         client = ldap_client()
 
         group = client.get_group(groupname)

--- a/fasjson/web/resources/groups.py
+++ b/fasjson/web/resources/groups.py
@@ -20,6 +20,14 @@ MemberModel = api_v1.model(
     },
 )
 
+SponsorModel = api_v1.model(
+    "Sponsor",
+    {
+        "username": fields.String(),
+        "uri": fields.Url("v1.users_user", absolute=True),
+    },
+)
+
 
 @api_v1.route("/")
 class GroupList(Resource):
@@ -70,3 +78,20 @@ class GroupMembers(Resource):
         return client.get_group_members(
             groupname, page_size=args.page_size, page_number=args.page_number
         )
+
+
+@api_v1.route("/<name:groupname>/sponsors/")
+@api_v1.param("groupname", "The group name")
+@api_v1.response(404, "Group not found")
+class GroupSponsors(Resource):
+    @api_v1.doc("get_group_sponsors")
+    @api_v1.marshal_with(SponsorModel)
+    def get(self, groupname):
+        """Fetch group members given the group name"""
+        client = ldap_client()
+
+        group = client.get_group(groupname)
+        if group is None:
+            api_v1.abort(404, "Group not found", groupname=groupname)
+
+        return client.get_group_sponsors(groupname)

--- a/fasjson/web/resources/users.py
+++ b/fasjson/web/resources/users.py
@@ -1,4 +1,4 @@
-from flask_restx import Resource
+from flask_restx import Resource, fields
 
 from fasjson.lib.ldap.models import UserModel as LDAPUserModel
 from fasjson.web.utils.ipa import ldap_client, get_fields_from_ldap_model
@@ -13,6 +13,14 @@ UserModel = api_v1.model(
     get_fields_from_ldap_model(
         LDAPUserModel, "v1.users_user", {"locked": {"default": False}}
     ),
+)
+
+UserGroupsModel = api_v1.model(
+    "UserGroup",
+    {
+        "groupname": fields.String(),
+        "uri": fields.Url("v1.groups_group", absolute=True),
+    },
 )
 
 
@@ -44,3 +52,24 @@ class User(Resource):
         if res is None:
             api_v1.abort(404, "User not found", name=username)
         return res
+
+
+@api_v1.route("/<name:username>/groups/")
+@api_v1.param("username", "The user name")
+@api_v1.response(404, "User not found")
+class UserGroups(Resource):
+    @api_v1.doc("list_users_groups")
+    @api_v1.expect(page_request_parser)
+    @api_v1.paged_marshal_with(UserGroupsModel, "v1.users_user_groups")
+    def get(self, username):
+        """Fetch a user's groups given their username"""
+        args = page_request_parser.parse_args()
+        client = ldap_client()
+        user = client.get_user(username)
+        if user is None:
+            api_v1.abort(404, "User does not exist", name=username)
+        return client.get_user_groups(
+            username=username,
+            page_size=args.page_size,
+            page_number=args.page_number,
+        )

--- a/fasjson/web/resources/users.py
+++ b/fasjson/web/resources/users.py
@@ -58,7 +58,7 @@ class User(Resource):
 @api_v1.param("username", "The user name")
 @api_v1.response(404, "User not found")
 class UserGroups(Resource):
-    @api_v1.doc("list_users_groups")
+    @api_v1.doc("list_user_groups")
     @api_v1.expect(page_request_parser)
     @api_v1.paged_marshal_with(UserGroupsModel, "v1.users_user_groups")
     def get(self, username):


### PR DESCRIPTION
The first gives the ability to return a list of sponsors of a group.
The second adds the ability to return the list of groups a user is a member of.

Signed-off-by: Stephen Coady <scoady@redhat.com>

Related: #63 