### PR TITLE
Only return users that have fasStatusNote = active

### DIFF
--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -121,7 +121,7 @@ class LDAP:
             "sn": surname,
         }
 
-        filter_string = ["(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(&"]
+        filter_string = ["(&", UserModel.filters, "(&"]
         for attribute, filter in filter_fields.items():
             if filter:
                 filter_value = ldap.filter.escape_filter_chars(filter, 0)

--- a/fasjson/lib/ldap/models.py
+++ b/fasjson/lib/ldap/models.py
@@ -37,7 +37,7 @@ class Model:
 
 class UserModel(Model):
     primary_key = "uid"
-    filters = "(&(objectClass=fasUser)(!(nsAccountLock=TRUE)))"
+    filters = "(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(fasStatusNote=active))"
     sub_dn = "cn=users,cn=accounts"
     fields = {
         "username": Converter("uid"),

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -252,7 +252,8 @@ def test_get_paged_search_filters(mock_connection):
 
     called_filters = [call[1]["filters"] for call in do_search.call_args_list]
     assert called_filters == [
-        "(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(&(uid=*something*)))"
+        "(&(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(fasStatusNote=active))"
+        "(&(uid=*something*)))"
     ]
     expected = LDAPResult(items=[], total=0, page_size=3, page_number=2,)
     assert result == expected
@@ -307,7 +308,8 @@ def test_get_paged_search_no_results(mock_connection):
     called_filters = [call[1]["filters"] for call in do_search.call_args_list]
     assert called_filters == [
         (
-            "(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(&(uid=*something*)"
+            "(&(&(objectClass=fasUser)(!(nsAccountLock=TRUE))(fasStatusNote=active))"
+            "(&(uid=*something*)"
             "(mail=something@example.test)(fasIRCNick=*something*)"
             "(givenName=*some*)(sn=*thing*)))"
         )


### PR DESCRIPTION
A component of the Basset integration described in fedora-infra/noggin#27 is to have FASJSON only return accounts that have passed the spam check. This PRs sets the correct filters for that.