### PR TITLE
Add an endpoint to check whether a user is a member of a group

### DIFF
--- a/fasjson/tests/unit/test_web_resource_base.py
+++ b/fasjson/tests/unit/test_web_resource_base.py
@@ -1,0 +1,40 @@
+import pytest
+from fasjson.web.resources.base import Namespace
+from flask_restx import fields
+
+
+@pytest.fixture
+def api():
+    return Namespace("test")
+
+
+def test_marshal_with_field(api):
+    class TestResource:
+        @api.marshal_with(fields.Boolean())
+        def get(self):
+            return True
+
+    resource = TestResource()
+    assert resource.get() == {"result": True}
+
+
+def test_marshal_with_field_class(api):
+    class TestResource:
+        @api.marshal_with(fields.Boolean)
+        def get(self):
+            return True
+
+    resource = TestResource()
+    assert resource.get() == {"result": True}
+
+
+def test_marshal_with_field_tuple_response(api):
+    headers = dict()
+
+    class TestResource:
+        @api.marshal_with(fields.Boolean())
+        def get(self):
+            return True, 200, headers
+
+    resource = TestResource()
+    assert resource.get() == ({"result": True}, 200, headers)

--- a/fasjson/web/resources/base.py
+++ b/fasjson/web/resources/base.py
@@ -1,15 +1,17 @@
 from functools import wraps
 
 from flask_restx import Namespace as RestXNamespace
-from flask_restx.utils import merge
+from flask_restx.utils import merge, unpack
 
 from ..utils.pagination import paged_marshal
 
 
 class Namespace(RestXNamespace):
-    def marshal_with(self, *args, **kwargs):
+    def marshal_with(self, fields, *args, **kwargs):
+        if not isinstance(fields, dict):
+            return self.marshal_with_field(fields, *args, **kwargs)
         kwargs.setdefault("envelope", "result")
-        return super().marshal_with(*args, **kwargs)
+        return super().marshal_with(fields, *args, **kwargs)
 
     def paged_marshal_with(
         self, model, endpoint, description=None, **marshal_kwargs
@@ -40,6 +42,32 @@ class Namespace(RestXNamespace):
                     ordered=self.ordered,
                     **marshal_kwargs
                 )
+
+            return wrapper
+
+        return decorator
+
+    def marshal_with_field(self, field, *args, description=None):
+        # Sadly we can't use flask_restx.marshalling.marshal_with_field because it does not
+        # support envelopes.
+        if isinstance(field, type):
+            field = field()
+
+        def decorator(func):
+            doc = {
+                "responses": {
+                    "200": (description, field, {"envelope": "result"})
+                },
+            }
+            func.__apidoc__ = merge(getattr(func, "__apidoc__", {}), doc)
+
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                result = func(*args, **kwargs)
+                if isinstance(result, tuple):
+                    data, code, headers = unpack(result)
+                    return {"result": field.format(data)}, code, headers
+                return {"result": field.format(result)}
 
             return wrapper
 


### PR DESCRIPTION
This changeset adds an endpoint to check whether a user is a member of a group without having to get the entire members list.

The return structure is a bit unusual for Flask-RestX, so I had to write more code than I hoped, but it should now be coherent with our return structures and have a nice OpenAPI documentation.

Fixes: #123