### PR TITLE
Handle python_freeipa exceptions that don't have a code attribute

### DIFF
--- a/fasjson/tests/unit/test_web_namespace.py
+++ b/fasjson/tests/unit/test_web_namespace.py
@@ -47,3 +47,16 @@ def test_rpc_bad_request(client, gss_user, mocker):
     assert body["message"] == "dummy message"
     assert body["code"] == 42
     assert body["source"] == "RPC"
+
+
+def test_rpc_bad_request_no_code(client, gss_user, mocker):
+    mocker.patch(
+        "fasjson.web.resources.certs.rpc_client",
+        side_effect=BadRequest(message="dummy message"),
+    )
+    rv = client.get("/v1/certs/1/")
+    assert rv.status_code == 400
+    body = json.loads(rv.data)
+    assert body["message"] == "dummy message"
+    assert body["code"] is None
+    assert body["source"] == "RPC"

--- a/fasjson/web/apis/base.py
+++ b/fasjson/web/apis/base.py
@@ -38,6 +38,8 @@ def handle_ldap_server_error(error):
 def handle_rpc_error(error):
     """When a JSON-RPC error occurs, return a 400 status code.
 
+    Warning, the exception does not always have a ``code`` attribute.
+
     Args:
         error (python_freeipa.exceptions.BadRequest): the exception that was raised
 
@@ -45,7 +47,7 @@ def handle_rpc_error(error):
         dict: a description of the error
     """
     return (
-        {"message": error.message, "code": error.code, "source": "RPC"},
+        {"message": error.message, "code": getattr(error, "code", None), "source": "RPC"},
         400,
     )
 


### PR DESCRIPTION
Some python_freeipa exceptions don't have a code attribute, don't crash when that happens.