### PR TITLE
bug: check for empty sponsors list in LDAPResult

### DIFF
--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -98,7 +98,7 @@ class LDAP:
             filters=filters,
             scope=ldap.SCOPE_SUBTREE,
         )
-        if not sponsors_result.items:
+        if not sponsors_result.items or 'sponsors' not in sponsors_result.items[0]:
             return []
         return self._sponsors_to_users(sponsors_result)
 

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -132,6 +132,27 @@ def test_get_group_sponsors(mock_connection):
     assert result == expected
 
 
+def test_get_group_sponsors_empty(mock_connection):
+    mocked = [
+        {
+            "memberManager": [
+                b"uid=admin,cn=users,cn=accounts,dc=example,dc=test"
+            ]
+        }
+    ]
+    mocked_conversion = LDAPResult()
+    mock_connection.result3 = _single_page_result_factory(mocked)
+
+    ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")
+    with mock.patch.object(
+        ldap, "search", side_effect=[mocked_conversion]
+    ):
+        result = ldap.get_group_sponsors(groupname="admins")
+
+    expected = []
+    assert result == expected
+
+
 def test_get_group_sponsors_none(mock_connection):
     mock_connection.result3 = _single_page_result_factory([])
     ldap = LDAP("ldap://dummy.com", basedn="dc=example,dc=test")


### PR DESCRIPTION
Signed-off-by: Stephen Coady <scoady@redhat.com>

<!--
Related Pull Request issue (if any)
-->
Fixes #

<!--
Please include what has changed
-->
## Proposed Changes

* Check for the 'sponsors' keyword to make sure it contains a result.

<!--
Steps required to validate your changes
-->
## Verification Steps

* Local fasjson server running
* Group created
* No sponsors for group
* curl /group/sponsors
* Should be an empty list

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes
