### PR TITLE
enable packit to give us automatic builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,90 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: python-fasjson.spec
+
+# add or remove files that should be synced
+files_to_sync:
+    - python-fasjson.spec
+    - .packit.yaml
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: fasjson
+# downstream (Fedora) RPM package name
+downstream_package_name: python-fasjson
+
+srpm_build_deps:
+  - wget
+
+actions:
+    create-archive:
+        - "poetry build -f sdist"
+        - "sh -c 'echo dist/fasjson-$(poetry version -s).tar.gz'"
+    get-current-version:
+        - "poetry version -s"
+    post-upstream-clone:
+         # we need poetry v1.1.7 because of a bug in 1.1.8 where python evaluates incorrectly
+        - "sh -c 'wget https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py && python3 install-poetry.py --version 1.1.7 && rm install-poetry.py'"
+
+jobs:
+  # upon upstream PRs, perform copr builds
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  - job: tests
+    trigger: pull_request
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  # upon upstream release, perform copr builds
+  - job: copr_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+      project: fasjson-client
+
+  # upon downstream changes, create a PR upstream with sync'd files from above
+  - job: sync_from_downstream
+    trigger: commit
+
+  # land upstream release in fedora dist-git - no builds
+  - job: propose_downstream
+    trigger: release
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development
+
+  # create an srpm from upstream and submit a scratch build to koji
+  - job: production_build
+    trigger: release
+    metadata:
+      targets:
+        - fedora-latest-stable
+        - fedora-development
+
+  # downstream automation
+
+  # trigger a build in koji for a new dist-git commit
+  - job: koji_build
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development
+
+  # create a new update in bodhi for a successful koji build. directly related to `koji_build`
+  - job: bodhi_update
+    trigger: commit
+    metadata:
+      dist_git_branches:
+        - fedora-latest-stable
+        - fedora-development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,12 @@ readme = 'README.md'
 repository = "https://github.com/fedora-infra/fasjson"
 homepage = "https://github.com/fedora-infra/fasjson"
 
+include = [
+  "devel/ansible/roles/fasjson/files/fasjson.wsgi",
+  "devel/ansible/roles/fasjson/files/config/",
+  "COPYING",
+]
+
 [tool.poetry.dependencies]
 python = "^3.6.2"
 Flask = "^2.0.2"

--- a/python-fasjson.spec
+++ b/python-fasjson.spec
@@ -1,8 +1,9 @@
 %global debug_package %{nil}
 %global ipa_version 4.8.0
+%global pypi_name fasjson
 
-Name:           fasjson
-Version:        0.0.1
+Name:           python-%{pypi_name}
+Version:        1.2.0
 Release:        1%{?dist}
 Summary:        JSON REST API for Fedora Account System
 
@@ -62,19 +63,19 @@ rm -rf $RPM_BUILD_ROOT
 %py3_install
 
 %__mkdir_p %{buildroot}%{_usr}/share/fasjson
-cp fasjson.wsgi %{buildroot}%{_usr}/share/fasjson
+cp devel/ansible/roles/fasjson/files/fasjson.wsgi %{buildroot}%{_usr}/share/fasjson
 
 %__mkdir_p %{buildroot}%{_sysconfdir}/gssproxy
-cp config/gssproxy-fasjson.conf %{buildroot}%{_sysconfdir}/gssproxy/99-fasjson.conf
+cp devel/ansible/roles/fasjson/files/config/gssproxy-fasjson.conf %{buildroot}%{_sysconfdir}/gssproxy/99-fasjson.conf
 
 %__mkdir_p %{buildroot}%{_unitdir}/httpd.service.d
-cp config/systemd-httpd-service-fasjson.conf  %{buildroot}/%{_unitdir}/httpd.service.d/fasjson.conf
+cp devel/ansible/roles/fasjson/files/config/systemd-httpd-service-fasjson.conf  %{buildroot}/%{_unitdir}/httpd.service.d/fasjson.conf
 
 %__mkdir_p %{buildroot}%{_sysconfdir}/httpd/conf.d
-cp config/httpd-fasjson.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/fasjson.conf
+cp devel/ansible/roles/fasjson/files/config/httpd-fasjson.conf %{buildroot}%{_sysconfdir}/httpd/conf.d/fasjson.conf
 
 %__mkdir_p %{buildroot}%{_tmpfilesdir}
-cp config/tmpfiles-fasjson.conf %{buildroot}%{_tmpfilesdir}/fasjson.conf
+cp devel/ansible/roles/fasjson/files/config/tmpfiles-fasjson.conf %{buildroot}%{_tmpfilesdir}/fasjson.conf
 
 
 %post
@@ -114,5 +115,8 @@ systemctl try-restart httpd.service
 
 
 %changelog
+* Mon May 09 2022 Stephen Coady <scoady@redhat.com> - 1.2.0-1
+- Bump specfile to 1.2.0
+
 * Tue Nov 19 2019 Christian Heimes <cheimes@redhat.com> - 0.0.1-1
 - Initial release


### PR DESCRIPTION
- enables packit
- small house keeping renaming the spec file to match fedora guidlines
- change the poetry build so files we need are included

Signed-off-by: Stephen Coady <scoady@redhat.com>