### PR TITLE
reduce flask dep strictness

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -914,7 +914,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9.0"
-content-hash = "d13de879635ef850f39875bd28d17ec9653df6809385e1899af703eba1e94996"
+content-hash = "229c07f90c821f0529552b77ddaf818997cbae8edfd0231961ee62e439c80d68"
 
 [metadata.files]
 aniso8601 = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ homepage = "https://github.com/fedora-infra/fasjson"
 
 [tool.poetry.dependencies]
 python = "^3.9.0"
-Flask = "^2.1.1"
+Flask = "^2.0.1"
 python-ldap = "^3.2.0"
 dnspython = "^2.1.0"
 flask-restx = "^0.5.0"


### PR DESCRIPTION
flask downstream is only available from 2.0.1 so it would be great to reduce the requirements here so we can package fasjson.

Signed-off-by: Stephen Coady <scoady@redhat.com>