### PR TITLE
Add seach options: `human_name` and `creation_before`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure(2) do |config|
   config.hostmanager.manage_guest = true
 
   config.vm.define "freeipa" do |freeipa|
-    freeipa.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-libvirt.box"
-    freeipa.vm.box = "f34-cloud-libvirt"
+    freeipa.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box"
+    freeipa.vm.box = "f36-cloud-libvirt"
     freeipa.vm.hostname = "ipa.example.test"
     freeipa.hostmanager.aliases = ("kerberos.example.test")
     
@@ -29,8 +29,8 @@ Vagrant.configure(2) do |config|
   end
   
   config.vm.define "fasjson" do |fasjson|
-    fasjson.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-libvirt.box"
-    fasjson.vm.box = "f34-cloud-libvirt"
+    fasjson.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-36-1.5.x86_64.vagrant-libvirt.box"
+    fasjson.vm.box = "f36-cloud-libvirt"
     fasjson.vm.hostname = "fasjson.example.test"
     
     fasjson.vm.synced_folder ".", "/vagrant/", type: "sshfs"

--- a/devel/ansible/roles/fasjson/tasks/main.yml
+++ b/devel/ansible/roles/fasjson/tasks/main.yml
@@ -22,6 +22,7 @@
       - vim
       - tmux
       - libffi-devel
+      - openldap-devel
     state: present
 
 - name: Allow apache to see /srv
@@ -55,6 +56,12 @@
     chdir: /vagrant/
   become: yes
   become_user: vagrant
+
+# https://github.com/python-ldap/python-ldap/issues/432#issuecomment-974799221
+- name: Workaround for python-ldap and openldap 2.5+
+  copy:
+    dest: /usr/lib64/libldap_r.so
+    content: INPUT ( libldap.so )
 
 - name: Install python dependencies with poetry
   shell: /srv/venv/bin/poetry install

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,9 +96,9 @@ autodoc_mock_imports = ["gssapi", "requests_gssapi"]
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 extlinks = {
-    "commit": ("https://github.com/fedora-infra/fasjson/commit/%s", ""),
-    "issue": ("https://github.com/fedora-infra/fasjson/issues/%s", "#"),
-    "pr": ("https://github.com/fedora-infra/fasjson/pull/%s", "PR#"),
+    "commit": ("https://github.com/fedora-infra/fasjson/commit/%s", "%s"),
+    "issue": ("https://github.com/fedora-infra/fasjson/issues/%s", "#%s"),
+    "pr": ("https://github.com/fedora-infra/fasjson/pull/%s", "PR#%s"),
 }
 
 

--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -231,7 +231,9 @@ class LDAP:
                 else:
                     filter_string.append(f"({attribute}=*{filter_value}*)")
         if creation_before:
-            filter_value = ldap.filter.escape_filter_chars(creation_before, 0)
+            filter_value = ldap.filter.escape_filter_chars(
+                creation_before.strftime("%Y%m%d%H%M%SZ"), 0
+            )
             filter_string.append(f"(fasCreationTime<={filter_value})")
         filter_string.append("))")
         filter_string = "".join(filter_string)

--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -211,6 +211,7 @@ class LDAP:
         givenname,
         surname,
         human_name,
+        creation_before,
     ):
         filter_fields = {
             "uid": username,
@@ -229,6 +230,9 @@ class LDAP:
                     filter_string.append(f"({attribute}={filter_value})")
                 else:
                     filter_string.append(f"({attribute}=*{filter_value}*)")
+        if creation_before:
+            filter_value = ldap.filter.escape_filter_chars(creation_before, 0)
+            filter_string.append(f"(fasCreationTime<={filter_value})")
         filter_string.append("))")
         filter_string = "".join(filter_string)
 

--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -210,6 +210,7 @@ class LDAP:
         ircnick,
         givenname,
         surname,
+        human_name,
     ):
         filter_fields = {
             "uid": username,
@@ -217,6 +218,7 @@ class LDAP:
             "fasIRCNick": ircnick,
             "givenName": givenname,
             "sn": surname,
+            "displayName": human_name,
         }
 
         filter_string = ["(&", UserModel.filters, "(&"]

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -396,6 +396,7 @@ def test_search_users(mock_connection):
         givenname="",
         surname="",
         human_name="",
+        creation_before="",
         attrs=None,
         page_number=1,
         page_size=0,
@@ -426,6 +427,7 @@ def test_search_users(mock_connection):
     [
         ({"username": "something"}, "(uid=*something*)"),
         ({"human_name": "something"}, "(displayName=*something*)"),
+        ({"creation_before": "20420101"}, "(fasCreationTime<=20420101)"),
     ],
 )
 def test_search_users_filters(
@@ -442,6 +444,7 @@ def test_search_users_filters(
         givenname="",
         surname="",
         human_name="",
+        creation_before="",
     )
     search_query.update(query)
 
@@ -475,6 +478,7 @@ def test_get_paged_search_filters(mock_connection):
             givenname=None,
             surname=None,
             human_name=None,
+            creation_before=None,
         )
 
     called_filters = [call[1]["filters"] for call in do_search.call_args_list]
@@ -536,6 +540,7 @@ def test_get_paged_search_no_results(mock_connection):
             givenname="some",
             surname="thing",
             human_name="something",
+            creation_before="",
         )
 
     called_filters = [call[1]["filters"] for call in do_search.call_args_list]

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -93,7 +93,10 @@ def test_get_groups_with_attrs(mock_connection, mocker):
         ["groupname", "url", "unknown"], page_number=1, page_size=0
     )
     mock_connection.search_ext.assert_called_once()
-    mock_connection.search_ext.call_args[1]["attrlist"] == ["cn", "fasUrl"]
+    assert mock_connection.search_ext.call_args[1]["attrlist"] == [
+        "cn",
+        "fasurl",
+    ]
 
 
 def test_get_group(mock_connection):
@@ -305,7 +308,10 @@ def test_get_user_with_attrs(mock_connection, mocker):
     ldap.get_user("admin", ["username", "surname"])
 
     mock_connection.search_ext.assert_called_once()
-    mock_connection.search_ext.call_args[1]["attrlist"] == ["uid", "sn"]
+    assert mock_connection.search_ext.call_args[1]["attrlist"] == [
+        "uid",
+        "sn",
+    ]
 
 
 def test_get_user_not_found(mock_connection):

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -433,7 +433,10 @@ def test_search_users(mock_connection):
     [
         ({"username": "something"}, "(uid=*something*)"),
         ({"human_name": "something"}, "(displayName=*something*)"),
-        ({"creation_before": "20420101"}, "(fasCreationTime<=20420101)"),
+        (
+            {"creation_before": datetime.datetime(2042, 1, 1)},
+            "(fasCreationTime<=20420101000000Z)",
+        ),
     ],
 )
 def test_search_users_filters(

--- a/fasjson/tests/unit/test_web_extension_ipacfg.py
+++ b/fasjson/tests/unit/test_web_extension_ipacfg.py
@@ -143,7 +143,7 @@ def test_detect_dns(mocker, app):
 
 def test_dns_query():
     resolver = mock.Mock()
-    resolver.query.return_value = _make_dns_answer(
+    resolver.resolve.return_value = _make_dns_answer(
         [
             dict(name="ldap1", priority=30),
             dict(name="ldap2", priority=20, weight=2),
@@ -161,7 +161,7 @@ def test_dns_query():
 def test_dns_query_same_prio_same_weight():
     names = ["ldap1", "ldap2", "ldap3"]
     resolver = mock.Mock()
-    resolver.query.return_value = _make_dns_answer(
+    resolver.resolve.return_value = _make_dns_answer(
         [{"name": name} for name in names]
     )
     result = query_srv("_ldap._tcp.example.com", resolver)
@@ -171,7 +171,7 @@ def test_dns_query_same_prio_same_weight():
 
 def test_dns_query_no_record():
     resolver = mock.Mock()
-    resolver.query.return_value = _make_dns_answer([])
+    resolver.resolve.return_value = _make_dns_answer([])
     result = query_srv("_ldap._tcp.example.com", resolver)
     assert len(result) == 0
 

--- a/fasjson/web/extensions/flask_ipacfg.py
+++ b/fasjson/web/extensions/flask_ipacfg.py
@@ -154,5 +154,5 @@ def query_srv(qname, resolver=None, **kwargs):
     """
     if resolver is None:
         resolver = dns.resolver
-    answer = resolver.query(qname, rdtype=dns.rdatatype.SRV, **kwargs)
+    answer = resolver.resolve(qname, rdtype=dns.rdatatype.SRV, **kwargs)
     return sort_prio_weight(answer)

--- a/fasjson/web/resources/search.py
+++ b/fasjson/web/resources/search.py
@@ -22,6 +22,9 @@ search_request_parser.add_argument(
 search_request_parser.add_argument(
     "surname", help="The surname to search for"
 )
+search_request_parser.add_argument(
+    "human_name", help="The full human name to search for"
+)
 
 
 api_v1 = Namespace("search", description="Search related operations")

--- a/fasjson/web/resources/search.py
+++ b/fasjson/web/resources/search.py
@@ -1,4 +1,5 @@
 from flask_restx import Resource
+from flask_restx.inputs import datetime_from_iso8601
 
 from fasjson.web.utils import maybe_anonymize
 from fasjson.web.utils.ipa import get_attrs_from_mask, ldap_client
@@ -26,7 +27,9 @@ search_request_parser.add_argument(
     "human_name", help="The full human name to search for"
 )
 search_request_parser.add_argument(
-    "creation_before", help="Search for users created before this date"
+    "creation_before",
+    help="Search for users created before this date",
+    type=datetime_from_iso8601,
 )
 
 
@@ -85,6 +88,8 @@ class SearchUsers(Resource):
         if not any(search_args.values()):
             api_v1.abort(400, "At least one search term must be provided.")
         for search_term, search_value in search_args.items():
+            if search_term == "creation_before":
+                continue  # It's a datetime already
             if search_value and len(search_value) < 3:
                 api_v1.abort(
                     400,

--- a/fasjson/web/resources/search.py
+++ b/fasjson/web/resources/search.py
@@ -25,6 +25,9 @@ search_request_parser.add_argument(
 search_request_parser.add_argument(
     "human_name", help="The full human name to search for"
 )
+search_request_parser.add_argument(
+    "creation_before", help="Search for users created before this date"
+)
 
 
 api_v1 = Namespace("search", description="Search related operations")

--- a/news/PR343.dev
+++ b/news/PR343.dev
@@ -1,0 +1,1 @@
+Upgrade the Vagrant VM to F36

--- a/news/PR343.feature
+++ b/news/PR343.feature
@@ -1,0 +1,1 @@
+Add the ``human_name`` and ``creation_before`` search terms for users


### PR DESCRIPTION
Add two search options:
- `human_name`: the full name of the user (`displayName` in LDAP)
- `creation_before`: the account was created before the specified date (`fasCreationTime` attribute)

In followup commits, upgrade the Vagrant VM to F36 and fix warnings.