### PR TITLE
Support presence match in the search endpoint

### DIFF
--- a/fasjson/lib/ldap/client.py
+++ b/fasjson/lib/ldap/client.py
@@ -32,6 +32,10 @@ class LDAPResult:
 
 
 def _get_filter_string(attribute, value, substring_match):
+    if value == "*":
+        # Presence match
+        return f"({attribute}=*)"
+
     value = ldap.filter.escape_filter_chars(value, 0)
     if substring_match:
         value = f"*{value}*"

--- a/fasjson/lib/ldap/models.py
+++ b/fasjson/lib/ldap/models.py
@@ -103,7 +103,19 @@ class UserModel(Model):
         "rssurl",
         "pronouns",
     ]
-    always_exact_match = ["email", "group"]
+    # Fields that do not have a SUBSTR index in the schema
+    # https://github.com/fedora-infra/freeipa-fas/blob/dev/schema.d/89-fasschema.ldif
+    always_exact_match = [
+        "email",
+        "creation",
+        "rhbzemail",
+        "github_username",
+        "gitlab_username",
+        "website",
+        "is_private",
+        "rssurl",
+        "group",
+    ]
 
     @classmethod
     def anonymize(cls, user):

--- a/fasjson/tests/unit/test_lib_ldap_client.py
+++ b/fasjson/tests/unit/test_lib_ldap_client.py
@@ -442,27 +442,38 @@ def test_search_users(mock_connection):
 @pytest.mark.parametrize(
     "query,expected_filter",
     [
+        # empty value
         ({"username": ""}, ""),
+        # substring match
         ({"username": "something"}, "(uid=*something*)"),
-        ({"username__exact": "something"}, "(uid=something)"),
         ({"human_name": "something"}, "(displayName=*something*)"),
+        # exact match
+        ({"username__exact": "something"}, "(uid=something)"),
         ({"human_name__exact": "something"}, "(displayName=something)"),
         (
             {"github_username__exact": "something"},
             "(fasGitHubUsername=something)",
         ),
+        # __before match
         (
             {"creation__before": datetime.datetime(2042, 1, 1)},
             "(fasCreationTime<=20420101000000Z)",
         ),
+        # Always exact match
         (
             {"rhbzemail": "something"},
-            "(fasRHBZEmail=*something*)",
+            "(fasRHBZEmail=something)",
         ),
         (
             {"rhbzemail__exact": "something"},
             "(fasRHBZEmail=something)",
         ),
+        # Presence match
+        (
+            {"rhbzemail": "*"},
+            "(fasRHBZEmail=*)",
+        ),
+        # Groups
         (
             {"group": ["something"]},
             "(memberof=cn=something,cn=groups,cn=accounts,dc=example,dc=test)",

--- a/news/presence-match.feature
+++ b/news/presence-match.feature
@@ -1,0 +1,1 @@
+Support presence match in the search endpoint. For example, use `ircnick=*` to get users who have defined an IRC nick.


### PR DESCRIPTION
For example, use `ircnick=*` to get users who have defined an IRC nick.