### PR TITLE
bump fedora container version to 44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:40
+FROM quay.io/fedora/fedora:44
 LABEL \
   name="fasjson" \
   vendor="Fedora Infrastructure" \


### PR DESCRIPTION
<!--
Related Pull Request issue (if any)
-->
Fixes #1027 

<!--
Please include what has changed
-->
## Proposed Changes

* A bump of the underlying Fedora image to the latest current version (44)

<!--
Steps required to validate your changes
-->
## Verification Steps

* Clone the repo and checkout my branch
* Run `docker build .`
* Build completes successfuly 

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes
N/A